### PR TITLE
make set_pv_value() do nothing if None is given as value

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -23,8 +23,6 @@ ignore = [
     "D406",  # Section name should end with a newline ("{name}")
     "D407",  # Missing dashed underline after section ("{name}")
     "N999",  # Ignore this because the repo itself would need to be renamed
-    "ANN101",  # ignore this until its removed in future versions
-    "ANN102",  # ignore this until its removed in future versions
     "ANN401", # explicit ANY type is allowed
 ]
 [lint.per-file-ignores]

--- a/src/genie_python/genie_epics_api.py
+++ b/src/genie_python/genie_epics_api.py
@@ -323,12 +323,18 @@ class API(object):
 
         Args:
             name: the PV name
-            value: the value to set
+            value: the value to set. If this is None, do nothing.
             wait: wait for the value to be set before returning
             is_local (bool, optional): whether to automatically prepend the
                                        local inst prefix to the PV name
             attempts: number of attempts to try to set the pv value
         """
+        if value is None:
+            self.logger.log_info_msg(
+                f"set_pv_value called with name={name} value={value} wait={wait}"
+                f" is_local={is_local} attempts={attempts} ignoring because value is None"
+            )
+            return
         if is_local:
             if not name.startswith(self.inst_prefix):
                 name = self.prefix_pv_name(name)


### PR DESCRIPTION
### Description of work

make set_pv_value() do nothing if `None` is given as a value. this will fail anyway at the ca level, so we should warn early and prevent an exception from being raised (or not as we don't raise them by default...) 

### To test

https://github.com/ISISComputingGroup/IBEX/issues/8612

### Acceptance criteria

see ticket

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
