### PR TITLE
fix cset type checking

### DIFF
--- a/src/genie_python/genie.py
+++ b/src/genie_python/genie.py
@@ -114,13 +114,13 @@ def get_block_units(block_name: str) -> str | dict | None:
 @helparglist("...")
 @log_command_and_handle_exception
 def cset(
-    *args: str,
+    *args: PVValue,
     runcontrol: bool | None = None,
     lowlimit: float | None = None,
     highlimit: float | None = None,
     wait: bool | None = None,
     verbose: bool | None = None,
-    **kwargs: bool | int | float | str | None,
+    **kwargs: PVValue,
 ) -> None:
     """
     Sets the setpoint and runcontrol settings for blocks.


### PR DESCRIPTION
This is a bit of a cover-all, but that's because `cset` has a very sloppy interface and lets you do weird things like cset(blockname=blockvalue) or cset("blockname", "blockvalue") etc. 

it at least passes pyright and allows all PV types. `None` will be covered by the underlying set_pv_value() call.

### Description of work

*Add your own description here*

### To test

*Which ticket does this PR fix?*

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
