### PR TITLE
Fixes genie script checker

### DIFF
--- a/src/genie_python/genie_script_checker.py
+++ b/src/genie_python/genie_script_checker.py
@@ -299,6 +299,7 @@ class ScriptChecker(object):
             init_hook = (
                 "import sys;"
                 'sys.path.append("{}");'
+                'sys.path.append("U:\\scripts");'
                 'sys.path.append("C:\\Instrument\\scripts");'.format(inst_file_path)
             )
             init_hook = init_hook.replace("\\", "\\\\")

--- a/src/genie_python/genie_script_checker.py
+++ b/src/genie_python/genie_script_checker.py
@@ -358,8 +358,7 @@ class ScriptChecker(object):
                 error_line = re.search(r"W:\s+(\d+):", warning)
                 if error_line:
                     selected_number = error_line.group(1)
-
-                error_line_numbers.append(int(selected_number))
+                    error_line_numbers.append(int(selected_number))
 
         lines_containing_errors = []
         with open(script_name) as f:


### PR DESCRIPTION
IMAT scripts were not being picked up by pylint as u:\scripts was not in its paths to check.

Also selected_number was undefined in some cases so fixed this by changing indentation.
Added u:\scripts to init_hook so considered by pylint now.

Tested on imat and works.