### PR TITLE
Type hint get_pv like cget

### DIFF
--- a/src/genie_python/genie.py
+++ b/src/genie_python/genie.py
@@ -729,7 +729,7 @@ def waitfor_move(*blocks: str | None, **kwargs: int | None) -> None:
 @log_command_and_handle_exception
 def get_pv(
     name: str, to_string: bool = False, is_local: bool = False, use_numpy: bool = False
-) -> PVValue:
+) -> Any:
     """
     Get the value for the specified PV.
 

--- a/tests/test_script_checker.py
+++ b/tests/test_script_checker.py
@@ -54,7 +54,7 @@ class TestScriptChecker(unittest.TestCase):
 
     def test_GIVEN_end_without_brackets_WHEN_check_THEN_error_message(self):
         script_lines = [
-            "from genie_python import genie as g\n" "def test():\n",
+            "from genie_python import genie as g\ndef test():\n",
             "   g.begin()\n",
             "   g.end\n",
         ]
@@ -65,14 +65,14 @@ class TestScriptChecker(unittest.TestCase):
             )
 
     def test_GIVEN_end_as_start_of_another_word_WHEN_check_THEN_no_error_message(self):
-        script_lines = ["from genie_python import genie as g\n" "def test():\n", "    endAngle = 1"]
+        script_lines = ["from genie_python import genie as g\ndef test():\n", "    endAngle = 1"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(errors, [])
 
     def test_GIVEN_end_as_end_of_another_word_WHEN_check_THEN_no_error_message(self):
         script_lines = [
-            "from genie_python import genie as g\n" "def test():\n",
+            "from genie_python import genie as g\ndef test():\n",
             "    angle_end = 1",
         ]
 
@@ -82,7 +82,7 @@ class TestScriptChecker(unittest.TestCase):
             self.assertEqual(errors, [])
 
     def test_GIVEN_end_without_brackets_at_start_of_line_WHEN_check_THEN_error_message(self):
-        script_lines = ["from genie_python import genie as g\n" "def test():\n" "   g.end"]
+        script_lines = ["from genie_python import genie as g\ndef test():\n   g.end"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(
@@ -92,7 +92,7 @@ class TestScriptChecker(unittest.TestCase):
     def test_GIVEN_end_without_brackets_on_line_with_fn_with_brackets_WHEN_check_THEN_error_message(
         self,
     ):
-        script_lines = ["from genie_python import genie as g\n" "g.begin(); g.end "]
+        script_lines = ["from genie_python import genie as g\ng.begin(); g.end "]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(
@@ -100,7 +100,7 @@ class TestScriptChecker(unittest.TestCase):
             )
 
     def test_GIVEN_end_in_string_without_brackets_WHEN_check_THEN_no_message(self):
-        script_lines = ["def test():\n" '   " a string containing end "']
+        script_lines = ['def test():\n   " a string containing end "']
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(errors, [])
@@ -202,9 +202,7 @@ class TestScriptChecker(unittest.TestCase):
             self.assertEqual(errors, [])
 
     def test_GIVEN_function_with_g_WHEN_check_THEN_warn_user(self):
-        script_lines = [
-            "from genie_python import genie as g\n" "def test():\n" "   g.test_function()\n"
-        ]
+        script_lines = ["from genie_python import genie as g\ndef test():\n   g.test_function()\n"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(
@@ -214,7 +212,7 @@ class TestScriptChecker(unittest.TestCase):
 
     def test_GIVEN_2_g_assignments_WHEN_check_THEN_warning_message(self):
         script_lines = [
-            "from genie_python import genie as g\n" "def test():\n" "    g=16\n",
+            "from genie_python import genie as g\ndef test():\n    g=16\n",
             "    g=17",
         ]
 
@@ -224,9 +222,7 @@ class TestScriptChecker(unittest.TestCase):
             )
 
     def test_GIVEN_g_non_existing_command_WHEN_call_THEN_error_message(self):
-        script_lines = [
-            "from genie_python import genie as g\n" "def test():\n" "  g.aitfor_time(10)"
-        ]
+        script_lines = ["from genie_python import genie as g\ndef test():\n  g.aitfor_time(10)"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(
@@ -450,6 +446,20 @@ class TestScriptChecker(unittest.TestCase):
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertTrue(expected in errors[0])
 
+    def test_GIVEN_two_get_pv_calls_with_arithmetic_operators_THEN_no_error(self):
+        script_lines = [
+            "from genie_python import genie as g\n",
+            "a = g.get_pv('...')\n",
+            "b = g.get_pv('...')\n",
+            "added = a + b\n",
+            "subtracted = a - b\n",
+            "multiplied = a * b\n",
+            "divided = a / b\n",
+        ]
+
+        with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
+            self.assertListEqual(errors, [])
+
     def test_GIVEN_new_directory_WHEN_pyright_script_checker_called_THEN_pyright_json_created_then_destroyed_after_use(
         self,
     ):
@@ -539,8 +549,7 @@ class TestScriptChecker(unittest.TestCase):
     ):
         script_lines = [
             "from typing import Optional, List\n",
-            "def get_first_element(elements: Optional[List[int]]) -> int:\n"
-            "   return elements[0]\n",
+            "def get_first_element(elements: Optional[List[int]]) -> int:\n   return elements[0]\n",
         ]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
@@ -563,7 +572,7 @@ class TestScriptChecker(unittest.TestCase):
     ):
         script_lines = [
             "from typing import Optional, List\n",
-            "def iter_elements(elements: Optional[List[int]]):\n" "   for element in elements:\n",
+            "def iter_elements(elements: Optional[List[int]]):\n   for element in elements:\n",
             "       pass\n",
         ]
 
@@ -573,7 +582,7 @@ class TestScriptChecker(unittest.TestCase):
     def test_GIVEN_trying_to_define_function_with_none_type_args_type_WHEN_pyright_script_checker_called_THEN_no_error(
         self,
     ):
-        script_lines = ["def none_func(arg: int = None):\n" "   print(arg)\n"]
+        script_lines = ["def none_func(arg: int = None):\n   print(arg)\n"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(errors, [])
@@ -581,7 +590,7 @@ class TestScriptChecker(unittest.TestCase):
     def test_GIVEN_trying_to_use_optional_operand__WHEN_pyright_script_checker_called_THEN_no_error(
         self,
     ):
-        script_lines = ["def none_func(arg1: int, arg2: int = None):\n" "   print(arg2 + arg1)\n"]
+        script_lines = ["def none_func(arg1: int, arg2: int = None):\n   print(arg2 + arg1)\n"]
 
         with CreateTempScriptAndReturnErrors(self.checker, self.machine, script_lines) as errors:
             self.assertEqual(errors, [])
@@ -589,7 +598,7 @@ class TestScriptChecker(unittest.TestCase):
     def test_GIVEN_trying_to_use_undefined_variable_WHEN_pyright_script_checker_called_THEN_no_error(
         self,
     ):
-        script_lines = ["def func():\n" "   print(arg)\n"]
+        script_lines = ["def func():\n   print(arg)\n"]
 
         with CreateTempScriptAndReturnErrors(
             self.checker, self.machine, script_lines, no_pylint=True


### PR DESCRIPTION
Pragmatic thing: we probably need to allow things like:

```
a = get_pv("...")
b = get_pv("...")
a + b
a - b
```

While the previous type hint was "more correct" it was giving too many errors on some real user scripts, need to be a bit pragmatic unfortunately I think. (pyright was checking _every combination_ of what `PVValue` could be, and reporting errors because some of those combinations like `list - float` are invalid)

Long term it would be nicer to have `g.get_pv[float]("...")` but that's not for a flash review.