### PR TITLE
Add warning on begin if using test clock

### DIFF
--- a/src/genie_python/genie_dae.py
+++ b/src/genie_python/genie_dae.py
@@ -339,6 +339,8 @@ class Dae(object):
         if not quiet:
             if self.get_simulation_mode():
                 self.simulation_mode_warning()
+            elif self.get_timing_source() == "Internal Test Clock":
+                self.test_clock_warning()
             print("** Beginning Run {} at {}".format(run_number, strftime("%H:%M:%S %d/%m/%y ")))
             ## don't fail begin() if we are unabel to print rb/user details
             try:
@@ -400,6 +402,15 @@ class Dae(object):
         print("\n=========== RUNNING IN SIMULATION MODE ===========\n")
         print("Simulation mode can be stopped using:               \n")
         print("         >>>set_dae_simulation_mode(False)          \n")
+        print("==================================================\n")
+        
+    def test_clock_warning(self) -> None:
+        """
+        Warn user they are using the test clock.
+        """
+        print("\n========= RUNNING AGAINST DAE TEST CLOCK =========\n")
+        print("Timing source can be changed using:               \n")
+        print("         >>>change_sync(source)                   \n")
         print("==================================================\n")
 
     def post_begin_check(self, verbose: bool = False) -> None:

--- a/src/genie_python/genie_dae.py
+++ b/src/genie_python/genie_dae.py
@@ -403,7 +403,7 @@ class Dae(object):
         print("Simulation mode can be stopped using:               \n")
         print("         >>>set_dae_simulation_mode(False)          \n")
         print("==================================================\n")
-        
+
     def test_clock_warning(self) -> None:
         """
         Warn user they are using the test clock.

--- a/tests/test_genie_dae.py
+++ b/tests/test_genie_dae.py
@@ -431,7 +431,7 @@ class TestGenieDAE(unittest.TestCase):
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
     def test_GIVEN_simulation_mode_AND_test_clock_WHEN_begin_run_THEN_user_is_warned(
-        self, mock_monitor
+        self, mock_monitor: MagicMock
     ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
@@ -449,7 +449,7 @@ class TestGenieDAE(unittest.TestCase):
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
     def test_GIVEN_in_test_clock_AND_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(
-        self, mock_monitor
+        self, mock_monitor: MagicMock
     ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
@@ -467,7 +467,7 @@ class TestGenieDAE(unittest.TestCase):
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
     def test_GIVEN_simulation_mode_AND_not_test_clock_WHEN_begin_run_THEN_user_is_warned(
-        self, mock_monitor
+        self, mock_monitor: MagicMock
     ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
@@ -485,7 +485,7 @@ class TestGenieDAE(unittest.TestCase):
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
     def test_GIVEN_not_in_test_clock_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(
-        self, mock_monitor
+        self, mock_monitor: MagicMock
     ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
@@ -741,7 +741,7 @@ class TestGenieAndSimulateDAEParity(unittest.TestCase):
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
     def test_GIVEN_in_setup_state_WHEN_begin_run_called_THEN_no_exception_thrown(
-        self, mock_monitor
+        self, mock_monitor: MagicMock
     ):
         mock_monitor.return_value = None
         self.set_run_state("SETUP")

--- a/tests/test_genie_dae.py
+++ b/tests/test_genie_dae.py
@@ -430,7 +430,9 @@ class TestGenieDAE(unittest.TestCase):
         func.assert_not_called()
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_simulation_mode_AND_test_clock_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_simulation_mode_AND_test_clock_WHEN_begin_run_THEN_user_is_warned(
+        self, mock_monitor
+    ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=True)
@@ -439,14 +441,16 @@ class TestGenieDAE(unittest.TestCase):
         clock_mock_warning = MagicMock()
         self.dae.test_clock_warning = clock_mock_warning
         self.dae.simulation_mode_warning = sim_mock_warning
-        
+
         self.dae.begin_run()
 
         sim_mock_warning.assert_called_once()
         clock_mock_warning.assert_not_called()
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_in_test_clock_AND_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_in_test_clock_AND_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(
+        self, mock_monitor
+    ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=False)
@@ -455,14 +459,16 @@ class TestGenieDAE(unittest.TestCase):
         clock_mock_warning = MagicMock()
         self.dae.test_clock_warning = clock_mock_warning
         self.dae.simulation_mode_warning = sim_mock_warning
-        
+
         self.dae.begin_run()
 
         sim_mock_warning.assert_not_called()
         clock_mock_warning.assert_called_once()
-        
+
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_simulation_mode_AND_not_test_clock_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_simulation_mode_AND_not_test_clock_WHEN_begin_run_THEN_user_is_warned(
+        self, mock_monitor
+    ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=True)
@@ -471,14 +477,16 @@ class TestGenieDAE(unittest.TestCase):
         clock_mock_warning = MagicMock()
         self.dae.test_clock_warning = clock_mock_warning
         self.dae.simulation_mode_warning = sim_mock_warning
-        
+
         self.dae.begin_run()
 
         sim_mock_warning.assert_called_once()
         clock_mock_warning.assert_not_called()
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_not_in_test_clock_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_not_in_test_clock_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(
+        self, mock_monitor
+    ):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=False)
@@ -487,7 +495,7 @@ class TestGenieDAE(unittest.TestCase):
         clock_mock_warning = MagicMock()
         self.dae.test_clock_warning = clock_mock_warning
         self.dae.simulation_mode_warning = sim_mock_warning
-        
+
         self.dae.begin_run()
 
         sim_mock_warning.assert_not_called()

--- a/tests/test_genie_dae.py
+++ b/tests/test_genie_dae.py
@@ -430,26 +430,68 @@ class TestGenieDAE(unittest.TestCase):
         func.assert_not_called()
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_simulation_mode_AND_test_clock_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=True)
-        mock_warning = MagicMock()
-        self.dae.simulation_mode_warning = mock_warning
+        self.dae.get_timing_source = MagicMock(return_value="Internal Test Clock")
+        sim_mock_warning = MagicMock()
+        clock_mock_warning = MagicMock()
+        self.dae.test_clock_warning = clock_mock_warning
+        self.dae.simulation_mode_warning = sim_mock_warning
+        
         self.dae.begin_run()
 
-        mock_warning.assert_called_once()
+        sim_mock_warning.assert_called_once()
+        clock_mock_warning.assert_not_called()
 
     @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
-    def test_GIVEN_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+    def test_GIVEN_in_test_clock_AND_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
         mock_monitor.return_value = None
         self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
         self.dae.get_simulation_mode = MagicMock(return_value=False)
-        mock_warning = MagicMock()
-        self.dae.simulation_mode_warning = mock_warning
+        self.dae.get_timing_source = MagicMock(return_value="Internal Test Clock")
+        sim_mock_warning = MagicMock()
+        clock_mock_warning = MagicMock()
+        self.dae.test_clock_warning = clock_mock_warning
+        self.dae.simulation_mode_warning = sim_mock_warning
+        
         self.dae.begin_run()
 
-        mock_warning.assert_not_called()
+        sim_mock_warning.assert_not_called()
+        clock_mock_warning.assert_called_once()
+        
+    @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
+    def test_GIVEN_simulation_mode_AND_not_test_clock_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+        mock_monitor.return_value = None
+        self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
+        self.dae.get_simulation_mode = MagicMock(return_value=True)
+        self.dae.get_timing_source = MagicMock(return_value="isis")
+        sim_mock_warning = MagicMock()
+        clock_mock_warning = MagicMock()
+        self.dae.test_clock_warning = clock_mock_warning
+        self.dae.simulation_mode_warning = sim_mock_warning
+        
+        self.dae.begin_run()
+
+        sim_mock_warning.assert_called_once()
+        clock_mock_warning.assert_not_called()
+
+    @patch("genie_python.genie_cachannel_wrapper.CaChannelWrapper.add_monitor")
+    def test_GIVEN_not_in_test_clock_not_in_simulation_mode_WHEN_begin_run_THEN_user_is_warned(self, mock_monitor):
+        mock_monitor.return_value = None
+        self.dae.api.get_pv_value = MagicMock(return_value="SETUP")
+        self.dae.get_simulation_mode = MagicMock(return_value=False)
+        self.dae.get_timing_source = MagicMock(return_value="isis")
+        sim_mock_warning = MagicMock()
+        clock_mock_warning = MagicMock()
+        self.dae.test_clock_warning = clock_mock_warning
+        self.dae.simulation_mode_warning = sim_mock_warning
+        
+        self.dae.begin_run()
+
+        sim_mock_warning.assert_not_called()
+        clock_mock_warning.assert_not_called()
 
     def get_y_or_yc_pv_value(self, pv, _, use_numpy=False):
         if "X" in pv:


### PR DESCRIPTION
### Description of work
Adds a warning to the `begin()` function if the scientists are using the test clock and are not in simulated DAE

### To test
https://github.com/ISISComputingGroup/IBEX/issues/8725

### Acceptance criteria
- [ ] When begining a run from a script if the dae is not simulated and the test clock is active, a warning is printed telling the user that the test clock is active and how to change there timing source.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
