### PR TITLE
Ticket8671 Give a better error when cache is corrupt

### DIFF
--- a/src/genie_python/genie_script_checker.py
+++ b/src/genie_python/genie_script_checker.py
@@ -210,11 +210,13 @@ class ScriptChecker(object):
             try:
                 json_data = json.loads(json_out)
             except json.decoder.JSONDecodeError:
-                errors.append("Failed to check the file with pyright, the user cache is corrupted."
-                              "\nPlease delete the folder "
-                              "C:\\Users\\<User>\\.cache\\pyright-python and try again.")
+                errors.append(
+                    "Failed to check the file with pyright, the user cache is corrupted."
+                    "\nPlease delete the folder "
+                    "C:\\Users\\<User>\\.cache\\pyright-python and try again."
+                )
                 return warnings, errors
-            
+
             # for each diagnostic, if severity is error then
             # add message to error array else add to warning array
             for diagnostic in json_data["generalDiagnostics"]:

--- a/src/genie_python/genie_script_checker.py
+++ b/src/genie_python/genie_script_checker.py
@@ -162,6 +162,7 @@ class ScriptChecker(object):
 
         def __enter__(self) -> None:
             self._filename = os.path.join(self.config_path, self.config_name)
+            print(self._filename)
             with open(self._filename, "w") as f:
                 f.write(json.dumps(self.json_write))
 
@@ -206,8 +207,13 @@ class ScriptChecker(object):
             pr_result = subprocess.run(args=cmd, capture_output=True, text=True, encoding="utf-8")
             json_out = unicodedata.normalize("NFKD", pr_result.stdout)
 
-            json_data = json.loads(json_out)
-
+            try:
+                json_data = json.loads(json_out)
+            except json.decoder.JSONDecodeError:
+                errors.append("Failed to check the file with pyright, the user cache is corrupted.\nPlease delete the"
+                              " folder C:\\Users\\<User>\\.cache\\pyright-python and try again.")
+                return warnings, errors
+            
             # for each diagnostic, if severity is error then
             # add message to error array else add to warning array
             for diagnostic in json_data["generalDiagnostics"]:

--- a/src/genie_python/genie_script_checker.py
+++ b/src/genie_python/genie_script_checker.py
@@ -210,8 +210,9 @@ class ScriptChecker(object):
             try:
                 json_data = json.loads(json_out)
             except json.decoder.JSONDecodeError:
-                errors.append("Failed to check the file with pyright, the user cache is corrupted.\nPlease delete the"
-                              " folder C:\\Users\\<User>\\.cache\\pyright-python and try again.")
+                errors.append("Failed to check the file with pyright, the user cache is corrupted."
+                              "\nPlease delete the folder "
+                              "C:\\Users\\<User>\\.cache\\pyright-python and try again.")
                 return warnings, errors
             
             # for each diagnostic, if severity is error then


### PR DESCRIPTION
### Description of work

Simple catch to make a more verbose error.

### To test

[Ticket8671](https://github.com/ISISComputingGroup/IBEX/issues/8671)

### Acceptance criteria

- Delete C:\Users\<user>\.cache\pyright-python\nodeenv\Scripts
- On main, try to load any script, it should have an unhelpful json error
- On this branch, it will tell you what to do
- Follow the prompts instructions, the script should now load

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
