### PR TITLE
Genie startup

### DIFF
--- a/src/genie_python/genie.py
+++ b/src/genie_python/genie.py
@@ -131,7 +131,7 @@ if not (MIN_SUPPORTED_PYTHON_VERSION <= sys.version_info[0:3] <= MAX_SUPPORTED_P
 
 
 @log_command_and_handle_exception
-def set_instrument(pv_prefix: str, import_instrument_init: bool = True) -> None:
+def set_instrument(pv_prefix: str | None, import_instrument_init: bool = True) -> None:
     """
     Sets the instrument this session is communicating with.
     Used for remote access - do not delete.

--- a/src/genie_python/genie_toggle_settings.py
+++ b/src/genie_python/genie_toggle_settings.py
@@ -17,10 +17,11 @@ class ToggleSettings:
 @usercommand
 @helparglist("")
 @log_command_and_handle_exception
-def exceptions_raised(toggle_on):
+def exceptions_raised(toggle_on: bool) -> None:
     """
     Set whether to allow exceptions to propagate (True) or let genie handle any exceptions (False).
-    By default (False), genie_python will handle any exceptions by printing the error message and carrying on.
+    By default (False), genie_python will handle any exceptions by printing the error message and
+    carrying on.
 
     Args:
         toggle_on (bool): Allow exceptions if True, let genie handle exceptions if False.
@@ -30,8 +31,6 @@ def exceptions_raised(toggle_on):
 
         >>> exceptions_raised(True)
     """
-    if not isinstance(toggle_on, bool):
-        raise ValueError("Exceptions raised setting needs to be True or False.")
     genie_python.genie_api_setup._exceptions_raised = toggle_on
     # noinspection PyProtectedMember
     print("Raise exceptions set to {}.".format(genie_python.genie_api_setup._exceptions_raised))
@@ -40,7 +39,7 @@ def exceptions_raised(toggle_on):
 @usercommand
 @helparglist("")
 @log_command_and_handle_exception
-def cset_verbose(verbose):
+def cset_verbose(verbose: bool) -> None:
     """
     Set the default verbosity of cset.
 
@@ -52,7 +51,5 @@ def cset_verbose(verbose):
 
         >>> cset_verbose(True)
     """
-    if not isinstance(verbose, bool):
-        raise ValueError("Default verbosity needs to be True or False.")
     ToggleSettings.cset_verbose = verbose
     print("Default cset verbosity set to {}.".format(ToggleSettings.cset_verbose))


### PR DESCRIPTION
Pyright checks returned one error:

> c:\Instrument\Dev\genie\src\genie_python\genie_startup.py
>   c:\Instrument\Dev\genie\src\genie_python\genie_startup.py:26:16 - error: Argument of type "None" cannot be assigned to parameter "pv_prefix" of type "str"
>     "None" is not assignable to "str" (reportArgumentType)
> 1 error, 0 warnings, 0 informations

This was the line it refered to: 

`# Call set_instrument with None to force it to try to guess the instrument
set_instrument(None)  # noqa F405 (defined from star import)`

This is the change I made to genie.py

`def set_instrument(pv_prefix: str | None, import_instrument_init: bool = True) -> None:`

Allowed 'None' to be a  pv_prefix


Please let me know if there was a better way to fix the pyright error!
