### PR TITLE
Make directory comparison case-insensitive

### DIFF
--- a/src/genie_python/genie.py
+++ b/src/genie_python/genie.py
@@ -1581,7 +1581,10 @@ def __load_module(name: str, directory: str) -> types.ModuleType:
 
     module_location = str(module_file)
 
-    if os.path.normpath(os.path.dirname(module_location)) != os.path.normpath(directory):
+    if (
+        os.path.normpath(os.path.dirname(module_location)).lower()
+        != os.path.normpath(directory).lower()
+    ):
         raise ValueError(err_msg)
 
     sys.modules[name] = module


### PR DESCRIPTION
Check on IMAT was getting confused between `u:\file.py` and `U:\file.py`.

I have no idea how or why windows chooses `u:\` vs `U:\` during `normpath`, but this should fix it...
